### PR TITLE
allow to check packages only for test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The following is an example configuration file.
   "packages": [
     "github.com/OpenPeeDeeP/depguard"
   ],
+  "inTests": [
+    "github.com/stretchr/testify"
+  ],
   "includeGoRoot": true
 }
 ```
@@ -35,6 +38,7 @@ The following is an example configuration file.
 - `type` can be either `whitelist` or `blacklist`. This check is case insensitive.
 If not specified the default is `blacklist`.
 - `packages` is a list of packages for the list type specified.
+- `inTests` is a list of packages allowed/disallowed only in test files.
 - Set `includeGoRoot` to true if you want to check the list against standard lib.
 If not specified the default is false.
 

--- a/cmd/depguard/main.go
+++ b/cmd/depguard/main.go
@@ -32,6 +32,7 @@ type config struct {
 	Type          string   `json:"type"`
 	Packages      []string `json:"packages"`
 	IncludeGoRoot bool     `json:"includeGoRoot"`
+	InTests       []string `json:"inTests"`
 	listType      depguard.ListType
 }
 
@@ -69,7 +70,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	conf, prog, err := getConfigAndProgram()
+	conf, prog, err := getConfigAndProgram(config)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -77,6 +78,7 @@ func main() {
 		Packages:      config.Packages,
 		IncludeGoRoot: config.IncludeGoRoot,
 		ListType:      config.listType,
+		TestPackages:  config.InTests,
 	}
 	issues, err := dg.Run(conf, prog)
 	if err != nil {
@@ -85,7 +87,7 @@ func main() {
 	printIssues(config, issues)
 }
 
-func getConfigAndProgram() (*loader.Config, *loader.Program, error) {
+func getConfigAndProgram(depguardConf *config) (*loader.Config, *loader.Program, error) {
 	paths := gotool.ImportPaths(flag.Args())
 	conf := new(loader.Config)
 	conf.ParserMode = parser.ImportsOnly
@@ -93,7 +95,7 @@ func getConfigAndProgram() (*loader.Config, *loader.Program, error) {
 	conf.TypeChecker = types.Config{
 		Error: eatErrors,
 	}
-	rest, err := conf.FromArgs(paths, false)
+	rest, err := conf.FromArgs(paths, len(depguardConf.InTests) > 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,5 +126,5 @@ func printIssues(c *config, issues []*depguard.Issue) {
 	}
 }
 
-//Since I am allowing errors to happen, I don't want them to print to screen.
+// Since I am allowing errors to happen, I don't want them to print to screen.
 func eatErrors(err error) {}

--- a/depguard.go
+++ b/depguard.go
@@ -11,44 +11,50 @@ import (
 	"golang.org/x/tools/go/loader"
 )
 
-//ListType states what kind of list is passed in.
+// ListType states what kind of list is passed in.
 type ListType int
 
 const (
-	//LTBlacklist states the list given is a blacklist. (default)
+	// LTBlacklist states the list given is a blacklist. (default)
 	LTBlacklist ListType = iota
-	//LTWhitelist states the list given is a whitelist.
+	// LTWhitelist states the list given is a whitelist.
 	LTWhitelist
 )
 
-//StringToListType makes it easier to turn a string into a ListType.
-//It assumes that the string representation is lower case.
+// StringToListType makes it easier to turn a string into a ListType.
+// It assumes that the string representation is lower case.
 var StringToListType = map[string]ListType{
 	"whitelist": LTWhitelist,
 	"blacklist": LTBlacklist,
 }
 
-//Issue with the package with PackageName at the Position.
+// Issue with the package with PackageName at the Position.
 type Issue struct {
 	PackageName string
 	Position    token.Position
 }
 
-//Depguard checks imports to make sure they follow the given list and constraints.
+// Depguard checks imports to make sure they follow the given list and constraints.
 type Depguard struct {
-	ListType       ListType
+	ListType      ListType
+	IncludeGoRoot bool
+
 	Packages       []string
-	IncludeGoRoot  bool
 	prefixPackages []string
 	globPackages   []glob.Glob
-	buildCtx       *build.Context
-	cwd            string
+
+	TestPackages       []string
+	prefixTestPackages []string
+	globTestPackages   []glob.Glob
+
+	buildCtx *build.Context
+	cwd      string
 }
 
-//Run checks for dependencies given the program and validates them against
-//Packages.
+// Run checks for dependencies given the program and validates them against
+// Packages.
 func (dg *Depguard) Run(config *loader.Config, prog *loader.Program) ([]*Issue, error) {
-	//Shortcut execution on an empty blacklist as that means every package is allowed
+	// Shortcut execution on an empty blacklist as that means every package is allowed
 	if dg.ListType == LTBlacklist && len(dg.Packages) == 0 {
 		return nil, nil
 	}
@@ -63,8 +69,14 @@ func (dg *Depguard) Run(config *loader.Config, prog *loader.Program) ([]*Issue, 
 	}
 	var issues []*Issue
 	for pkg, positions := range directImports {
-		if dg.flagIt(pkg) {
-			for _, pos := range positions {
+		for _, pos := range positions {
+
+			prefixList, globList := dg.prefixPackages, dg.globPackages
+			if len(dg.TestPackages) > 0 && strings.Index(pos.Filename, "_test.go") != -1 {
+				prefixList, globList = dg.prefixTestPackages, dg.globTestPackages
+			}
+
+			if dg.flagIt(pkg, prefixList, globList) {
 				issues = append(issues, &Issue{
 					PackageName: pkg,
 					Position:    pos,
@@ -76,7 +88,7 @@ func (dg *Depguard) Run(config *loader.Config, prog *loader.Program) ([]*Issue, 
 }
 
 func (dg *Depguard) initialize(config *loader.Config, prog *loader.Program) error {
-	//Try and get the current working directory
+	// Try and get the current working directory
 	dg.cwd = config.Cwd
 	if dg.cwd == "" {
 		var err error
@@ -86,12 +98,13 @@ func (dg *Depguard) initialize(config *loader.Config, prog *loader.Program) erro
 		}
 	}
 
-	//Use the &build.Default if one is not specified
+	// Use the &build.Default if one is not specified
 	dg.buildCtx = config.Build
 	if dg.buildCtx == nil {
 		dg.buildCtx = &build.Default
 	}
 
+	// parse ordinary guarded packages
 	for _, pkg := range dg.Packages {
 		if strings.ContainsAny(pkg, "!?*[]{}") {
 			g, err := glob.Compile(pkg, '/')
@@ -104,19 +117,36 @@ func (dg *Depguard) initialize(config *loader.Config, prog *loader.Program) erro
 		}
 	}
 
-	//Sort the packages so we can have a faster search in the array
+	// Sort the packages so we can have a faster search in the array
 	sort.Strings(dg.prefixPackages)
+
+	// parse guarded tests packages
+	for _, pkg := range dg.TestPackages {
+		if strings.ContainsAny(pkg, "!?*[]{}") {
+			g, err := glob.Compile(pkg, '/')
+			if err != nil {
+				return err
+			}
+			dg.globTestPackages = append(dg.globTestPackages, g)
+		} else {
+			dg.prefixTestPackages = append(dg.prefixTestPackages, pkg)
+		}
+	}
+
+	// Sort the test packages so we can have a faster search in the array
+	sort.Strings(dg.prefixTestPackages)
+
 	return nil
 }
 
 func (dg *Depguard) createImportMap(prog *loader.Program) (map[string][]token.Position, error) {
 	importMap := make(map[string][]token.Position)
-	//For the directly imported packages
+	// For the directly imported packages
 	for _, imported := range prog.InitialPackages() {
-		//Go through their files
+		// Go through their files
 		for _, file := range imported.Files {
-			//And populate a map of all direct imports and their positions
-			//This will filter out GoRoot depending on the Depguard.IncludeGoRoot
+			// And populate a map of all direct imports and their positions
+			// This will filter out GoRoot depending on the Depguard.IncludeGoRoot
 			for _, fileImport := range file.Imports {
 				fileImportPath := cleanBasicLitString(fileImport.Path.Value)
 				if !dg.IncludeGoRoot {
@@ -143,29 +173,29 @@ func (dg *Depguard) createImportMap(prog *loader.Program) (map[string][]token.Po
 	return importMap, nil
 }
 
-func (dg *Depguard) pkgInList(pkg string) bool {
-	if dg.pkgInPrefixList(pkg) {
+func (dg *Depguard) pkgInList(pkg string, prefixList []string, globList []glob.Glob) bool {
+	if dg.pkgInPrefixList(pkg, prefixList) {
 		return true
 	}
-	return dg.pkgInGlobList(pkg)
+	return dg.pkgInGlobList(pkg, globList)
 }
 
-func (dg *Depguard) pkgInPrefixList(pkg string) bool {
-	//Idx represents where in the package slice the passed in package would go
-	//when sorted. -1 Just means that it would be at the very front of the slice.
-	idx := sort.Search(len(dg.prefixPackages), func(i int) bool {
-		return dg.prefixPackages[i] > pkg
+func (dg *Depguard) pkgInPrefixList(pkg string, prefixList []string) bool {
+	// Idx represents where in the package slice the passed in package would go
+	// when sorted. -1 Just means that it would be at the very front of the slice.
+	idx := sort.Search(len(prefixList), func(i int) bool {
+		return prefixList[i] > pkg
 	}) - 1
-	//This means that the package passed in has no way to be prefixed by anything
-	//in the package list as it is already smaller then everything
+	// This means that the package passed in has no way to be prefixed by anything
+	// in the package list as it is already smaller then everything
 	if idx == -1 {
 		return false
 	}
-	return strings.HasPrefix(pkg, dg.prefixPackages[idx])
+	return strings.HasPrefix(pkg, prefixList[idx])
 }
 
-func (dg *Depguard) pkgInGlobList(pkg string) bool {
-	for _, g := range dg.globPackages {
+func (dg *Depguard) pkgInGlobList(pkg string, globList []glob.Glob) bool {
+	for _, g := range globList {
 		if g.Match(pkg) {
 			return true
 		}
@@ -173,11 +203,11 @@ func (dg *Depguard) pkgInGlobList(pkg string) bool {
 	return false
 }
 
-//InList | WhiteList | BlackList
+// InList | WhiteList | BlackList
 //   y   |           |     x
 //   n   |     x     |
-func (dg *Depguard) flagIt(pkg string) bool {
-	return dg.pkgInList(pkg) == (dg.ListType == LTBlacklist)
+func (dg *Depguard) flagIt(pkg string, prefixList []string, globList []glob.Glob) bool {
+	return dg.pkgInList(pkg, prefixList, globList) == (dg.ListType == LTBlacklist)
 }
 
 func cleanBasicLitString(value string) string {


### PR DESCRIPTION
This patch adds new config option `inTests`. It allows to specify list of packages to be checked only against test files (e.g. `*_test.go`)