### PR TITLE
Add ability to include error messages with package checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The following is an example configuration file.
   "packages": [
     "github.com/OpenPeeDeeP/depguard"
   ],
+  "packageErrorMessages":  {
+    "github.com/OpenPeeDeeP/depguards": "Please use \"github.com/OpenPeeDeeP/depguard\","
+  },
   "inTests": [
     "github.com/stretchr/testify"
   ],
@@ -38,6 +41,7 @@ The following is an example configuration file.
 - `type` can be either `whitelist` or `blacklist`. This check is case insensitive.
 If not specified the default is `blacklist`.
 - `packages` is a list of packages for the list type specified.
+- `packageErrorMessages` is a mapping from packages to the error message to display
 - `inTests` is a list of packages allowed/disallowed only in test files.
 - Set `includeGoRoot` to true if you want to check the list against standard lib.
 If not specified the default is false.


### PR DESCRIPTION
**Summary**
This adds a new field that allows users to supply a map of packages and an associated error message to provide users when that package causes an issue. 

**Motivation**
I have been using it recently to help with migrations, but wanted a way to give people more context when they run into a linting error caused by this package. 

**Impact**
This has no impact on the previous functionality of the library.  This only extends the functionality.

This adds a new field `packagesWithErrorMessages` to the config and adds any packages that exist in this map to the `Packages` value on the config struct if the package type is a blacklist.  In the case of a whitelist it does not make sense to add these packages to the `Packages` list, but it is usual to provide a message still for users to use a whitelist package.
```JSON
{
  "type": "blacklist",
  "packagesWithErrorMessages": {
    "github.com/pkg/errors": "Use `fmt.Errorf` instead"
  }
}
```

This produces error messages that give more context like which are super helpful for large repo migrations:

![image](https://user-images.githubusercontent.com/11651981/64226397-1ab40d80-ce94-11e9-9197-316cd9efd596.png)
