### PR TITLE
Ignore File Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,19 @@ The following is an example configuration file.
 
 ### Ignore File Rules
 
-The configuration also allows you to specify rules to ignore certain files considered by the linter. This means that you need not apply package import checks across your entire code base.
+The configuration also allows us to specify rules to ignore certain files considered by the linter. This means that we need not apply package import checks across our entire code base.
 
 For example, consider the following configuration to block a test package:
 ```json
 {
   "type": "denylist",
+   // NOTE: Required due to shortcut logic in the linter
+  "packages": ["github.com/stretchr/testify"],
   "inTests": ["github.com/stretchr/testify"]
 }
 ```
 
-We can use a `ignoreFileRules` field to write a semantically equivalent configuration:
+We can use a `ignoreFileRules` field to write a configuration that only considers test files:
 ```json
 {
   "type": "denylist",
@@ -64,7 +66,7 @@ We can use a `ignoreFileRules` field to write a semantically equivalent configur
 }
 ```
 
-Or if you wanted to consider only non-test files:
+Or if we wanted to consider only non-test files:
 ```json
 {
   "type": "denylist",

--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ The following is an example configuration file.
 - Set `includeGoStdLib` (`includeGoRoot` for backwards compatibility) to true if you want to check the list against standard lib.
   If not specified the default is false.
 
+### Ignore File Rules
+
+The configuration also allows you to specify rules to ignore certain files considered by the linter. This means that you need not apply package import checks across your entire code base.
+
+For example, consider the following configuration to block a test package:
+```json
+{
+  "type": "denylist",
+  "inTests": ["github.com/stretchr/testify"]
+}
+```
+
+We can use a `ignoreFileRules` field to write a semantically equivalent configuration:
+```json
+{
+  "type": "denylist",
+  "packages": ["github.com/stretchr/testify"],
+  "ignoreFileRules": ["!**/*_test.go"]
+}
+```
+
+Or if you wanted to consider only non-test files:
+```json
+{
+  "type": "denylist",
+  "packages": ["github.com/stretchr/testify"],
+  "ignoreFileRules": ["**/*_test.go"]
+}
+```
+
+Like the `packages` field, the `ignoreFileRules` field can accept both string prefixes and string glob patterns. Note in the first example above, the use of the `!` character in front of the rule. This is a special character which signals that the linter should negate the rule. This allows for more precise control, but it is only available for glob patterns.
+
 ## Gometalinter
 
 The binary installation of this linter can be used with

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ For example, consider the following configuration to block a test package:
 ```json
 {
   "type": "denylist",
-   // NOTE: Required due to shortcut logic in the linter
   "packages": ["github.com/stretchr/testify"],
   "inTests": ["github.com/stretchr/testify"]
 }

--- a/cmd/depguard/main.go
+++ b/cmd/depguard/main.go
@@ -43,6 +43,7 @@ type config struct {
 	IncludeGoRoot             bool              `json:"includeGoRoot"`
 	IncludeGoStdLib           bool              `json:"includeGoStdLib"`
 	InTests                   []string          `json:"inTests"`
+	IgnoreFileRules           []string          `json:"ignoreFileRules"`
 	listType                  depguard.ListType
 }
 
@@ -118,10 +119,11 @@ func main() {
 		log.Fatalln(err)
 	}
 	dg := &depguard.Depguard{
-		Packages:      config.Packages,
-		IncludeGoRoot: config.IncludeGoRoot,
-		ListType:      config.listType,
-		TestPackages:  config.InTests,
+		Packages:        config.Packages,
+		IncludeGoRoot:   config.IncludeGoRoot,
+		ListType:        config.listType,
+		TestPackages:    config.InTests,
+		IgnoreFileRules: config.IgnoreFileRules,
 	}
 	issues, err := dg.Run(conf, prog)
 	if err != nil {

--- a/depguard.go
+++ b/depguard.go
@@ -81,14 +81,13 @@ func (dg *Depguard) Run(config *loader.Config, prog *loader.Program) ([]*Issue, 
 	var issues []*Issue
 	for pkg, positions := range directImports {
 		for _, pos := range positions {
+			if ignoreFile(pos.Filename, dg.prefixIgnoreFileRules, dg.globIgnoreFileRules) {
+				continue
+			}
 
 			prefixList, globList := dg.prefixPackages, dg.globPackages
 			if len(dg.TestPackages) > 0 && strings.Index(pos.Filename, "_test.go") != -1 {
 				prefixList, globList = dg.prefixTestPackages, dg.globTestPackages
-			}
-
-			if ignoreFile(pos.Filename, dg.prefixIgnoreFileRules, dg.globIgnoreFileRules) {
-				continue
 			}
 
 			if dg.flagIt(pkg, prefixList, globList) {

--- a/depguard_test.go
+++ b/depguard_test.go
@@ -106,6 +106,31 @@ func TestMixedTestFileAllowList(t *testing.T) {
 	require.Equal(t, "file_test.go", issues[0].Position.Filename)
 }
 
+func TestExcludeGoRootAllowList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTWhitelist,
+		Packages: []string{"allow"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
+}
+
+func TestIncludeGoRootAllowList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType:      depguard.LTWhitelist,
+		Packages:      []string{"allow"},
+		IncludeGoRoot: true,
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	require.Equal(t, "go/ast", issues[0].PackageName)
+	require.Equal(t, "file.go", issues[0].Position.Filename)
+}
+
 // ========== DenyList ==========
 
 func TestBasicDenyList(t *testing.T) {
@@ -226,6 +251,31 @@ func TestMixedTestFileDenyList(t *testing.T) {
 	require.Len(t, issues, 1)
 	require.Equal(t, "denytest/a", issues[0].PackageName)
 	require.Equal(t, "file_test.go", issues[0].Position.Filename)
+}
+
+func TestExcludeGoRootDenyList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTBlacklist,
+		Packages: []string{"go/ast"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
+}
+
+func TestIncludeGoRootDenyList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType:      depguard.LTBlacklist,
+		Packages:      []string{"go/ast"},
+		IncludeGoRoot: true,
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	require.Equal(t, "go/ast", issues[0].PackageName)
+	require.Equal(t, "file.go", issues[0].Position.Filename)
 }
 
 func newLoadConfig() *loader.Config {

--- a/depguard_test.go
+++ b/depguard_test.go
@@ -60,7 +60,7 @@ func TestMixedAllowList(t *testing.T) {
 	require.Equal(t, "file.go", issues[0].Position.Filename)
 }
 
-func TestBasicTestFileAllowList(t *testing.T) {
+func TestBasicTestPackagesAllowList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTWhitelist,
 		TestPackages: []string{"allowtest"},
@@ -71,7 +71,7 @@ func TestBasicTestFileAllowList(t *testing.T) {
 	require.Len(t, issues, 0)
 }
 
-func TestPrefixTestFileAllowList(t *testing.T) {
+func TestPrefixTestPackagesAllowList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTWhitelist,
 		TestPackages: []string{"allowtest"},
@@ -82,7 +82,7 @@ func TestPrefixTestFileAllowList(t *testing.T) {
 	require.Len(t, issues, 0)
 }
 
-func TestGlobTestFileAllowList(t *testing.T) {
+func TestGlobTestPackagesAllowList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTWhitelist,
 		TestPackages: []string{"allowtest/**/pkg"},
@@ -93,7 +93,7 @@ func TestGlobTestFileAllowList(t *testing.T) {
 	require.Len(t, issues, 0)
 }
 
-func TestMixedTestFileAllowList(t *testing.T) {
+func TestMixedTestPackagesAllowList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTWhitelist,
 		TestPackages: []string{"allowtest"},
@@ -281,7 +281,7 @@ func TestMixedDenyList(t *testing.T) {
 	require.Equal(t, "file.go", issues[0].Position.Filename)
 }
 
-func TestBasicTestFileDenyList(t *testing.T) {
+func TestBasicTestPackagesDenyList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTBlacklist,
 		Packages:     []string{"deny"}, // NOTE: Linter will shortcut with no package deny list
@@ -295,7 +295,7 @@ func TestBasicTestFileDenyList(t *testing.T) {
 	require.Equal(t, "file_test.go", issues[0].Position.Filename)
 }
 
-func TestPrefixTestFileDenyList(t *testing.T) {
+func TestPrefixTestPackagesDenyList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTBlacklist,
 		Packages:     []string{"deny"}, // NOTE: Linter will shortcut with no package deny list
@@ -312,7 +312,7 @@ func TestPrefixTestFileDenyList(t *testing.T) {
 	require.Equal(t, "file_test.go", issues[1].Position.Filename)
 }
 
-func TestGlobTestFileDenyList(t *testing.T) {
+func TestGlobTestPackagesDenyList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTBlacklist,
 		Packages:     []string{"deny"}, // NOTE: Linter will shortcut with no package deny list
@@ -329,7 +329,7 @@ func TestGlobTestFileDenyList(t *testing.T) {
 	require.Equal(t, "file_test.go", issues[1].Position.Filename)
 }
 
-func TestMixedTestFileDenyList(t *testing.T) {
+func TestMixedTestPackagesDenyList(t *testing.T) {
 	dg := depguard.Depguard{
 		ListType:     depguard.LTBlacklist,
 		Packages:     []string{"deny"}, // NOTE: Linter will shortcut with no package deny list

--- a/depguard_test.go
+++ b/depguard_test.go
@@ -20,7 +20,7 @@ func TestBasicAllowList(t *testing.T) {
 		Packages: []string{"allow"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "allow"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -31,7 +31,7 @@ func TestPrefixAllowList(t *testing.T) {
 		Packages: []string{"allow"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a", "allow/b"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "allow/a", "allow/b"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -42,7 +42,7 @@ func TestGlobAllowList(t *testing.T) {
 		Packages: []string{"allow/**/pkg"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a/pkg", "allow/b/c/pkg"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "allow/a/pkg", "allow/b/c/pkg"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -53,7 +53,7 @@ func TestMixedAllowList(t *testing.T) {
 		Packages: []string{"allow"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a", "deny/a"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "allow/a", "deny/a"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "deny/a", issues[0].PackageName)
@@ -66,7 +66,7 @@ func TestBasicTestFileAllowList(t *testing.T) {
 		TestPackages: []string{"allowtest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "allowtest"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "allowtest"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -77,7 +77,7 @@ func TestPrefixTestFileAllowList(t *testing.T) {
 		TestPackages: []string{"allowtest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "allowtest/a", "allowtest/b"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "allowtest/a", "allowtest/b"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -88,7 +88,7 @@ func TestGlobTestFileAllowList(t *testing.T) {
 		TestPackages: []string{"allowtest/**/pkg"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "allowtest/a/pkg", "allowtest/b/c/pkg"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "allowtest/a/pkg", "allowtest/b/c/pkg"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -99,7 +99,7 @@ func TestMixedTestFileAllowList(t *testing.T) {
 		TestPackages: []string{"allowtest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "allowtest/a", "denytest/a"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "allowtest/a", "denytest/a"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "denytest/a", issues[0].PackageName)
@@ -112,7 +112,7 @@ func TestExcludeGoRootAllowList(t *testing.T) {
 		Packages: []string{"allow"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "go/ast"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -124,7 +124,7 @@ func TestIncludeGoRootAllowList(t *testing.T) {
 		IncludeGoRoot: true,
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "go/ast"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "go/ast", issues[0].PackageName)
@@ -139,7 +139,7 @@ func TestBasicDenyList(t *testing.T) {
 		Packages: []string{"deny"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "deny"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "deny", issues[0].PackageName)
@@ -152,7 +152,7 @@ func TestPrefixDenyList(t *testing.T) {
 		Packages: []string{"deny"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny/a", "deny/b"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "deny/a", "deny/b"))
 	require.NoError(t, err)
 	require.Len(t, issues, 2)
 	sortIssues(issues)
@@ -168,7 +168,7 @@ func TestGlobDenyList(t *testing.T) {
 		Packages: []string{"deny/**/pkg"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny/a/pkg", "deny/b/c/pkg"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "deny/a/pkg", "deny/b/c/pkg"))
 	require.NoError(t, err)
 	require.Len(t, issues, 2)
 	sortIssues(issues)
@@ -184,7 +184,7 @@ func TestMixedDenyList(t *testing.T) {
 		Packages: []string{"deny"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a", "deny/a"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "allow/a", "deny/a"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "deny/a", issues[0].PackageName)
@@ -198,7 +198,7 @@ func TestBasicTestFileDenyList(t *testing.T) {
 		TestPackages: []string{"denytest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "denytest"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "denytest"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "denytest", issues[0].PackageName)
@@ -212,7 +212,7 @@ func TestPrefixTestFileDenyList(t *testing.T) {
 		TestPackages: []string{"denytest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "denytest/a", "denytest/b"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "denytest/a", "denytest/b"))
 	require.NoError(t, err)
 	require.Len(t, issues, 2)
 	sortIssues(issues)
@@ -229,7 +229,7 @@ func TestGlobTestFileDenyList(t *testing.T) {
 		TestPackages: []string{"denytest/**/pkg"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "denytest/a/pkg", "denytest/b/c/pkg"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "denytest/a/pkg", "denytest/b/c/pkg"))
 	require.NoError(t, err)
 	require.Len(t, issues, 2)
 	sortIssues(issues)
@@ -246,7 +246,7 @@ func TestMixedTestFileDenyList(t *testing.T) {
 		TestPackages: []string{"denytest"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file_test.go", "allowtest/a", "denytest/a"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file_test.go", "allowtest/a", "denytest/a"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "denytest/a", issues[0].PackageName)
@@ -259,7 +259,7 @@ func TestExcludeGoRootDenyList(t *testing.T) {
 		Packages: []string{"go/ast"},
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "go/ast"))
 	require.NoError(t, err)
 	require.Len(t, issues, 0)
 }
@@ -271,7 +271,7 @@ func TestIncludeGoRootDenyList(t *testing.T) {
 		IncludeGoRoot: true,
 	}
 
-	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "go/ast"))
+	issues, err := dg.Run(newLoadConfig(), newSimpleProgram("file.go", "go/ast"))
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "go/ast", issues[0].PackageName)
@@ -285,26 +285,36 @@ func newLoadConfig() *loader.Config {
 	}
 }
 
-func newProgram(fileName string, packagePaths ...string) *loader.Program {
-	// Build up a mini AST of the information we need to run the linter
-	var packageImports []*ast.ImportSpec
-	for i, _ := range packagePaths {
-		packagePath := packagePaths[i]
-		packageImports = append(packageImports, &ast.ImportSpec{
-			Path: &ast.BasicLit{
-				ValuePos: token.Pos(1),
-				Kind:     token.STRING,
-				Value:    packagePath,
-			},
-		})
-	}
+func newSimpleProgram(fileName string, packagePaths ...string) *loader.Program {
+	filesAndPackagePaths := make(map[string][]string, 1)
+	filesAndPackagePaths[fileName] = packagePaths
+	return newProgram(filesAndPackagePaths)
+}
 
-	astFile := &ast.File{
-		Imports: packageImports,
-	}
-
+func newProgram(filesAndPackagePaths map[string][]string) *loader.Program {
+	var astFiles []*ast.File
 	progFileSet := token.NewFileSet()
-	progFileSet.AddFile(fileName, 1, 0)
+
+	for fileName, packagePaths := range filesAndPackagePaths {
+		// Build up a mini AST of the information we need to run the linter
+		var packageImports []*ast.ImportSpec
+		for i, _ := range packagePaths {
+			packagePath := packagePaths[i]
+			packageImports = append(packageImports, &ast.ImportSpec{
+				Path: &ast.BasicLit{
+					ValuePos: token.Pos(i + 1),
+					Kind:     token.STRING,
+					Value:    packagePath,
+				},
+			})
+		}
+
+		astFiles = append(astFiles, &ast.File{
+			Imports: packageImports,
+		})
+
+		progFileSet.AddFile(fileName, len(astFiles), len(packageImports))
+	}
 
 	return &loader.Program{
 		Created: []*loader.PackageInfo{
@@ -313,7 +323,7 @@ func newProgram(fileName string, packagePaths ...string) *loader.Program {
 				Importable:            true,
 				TransitivelyErrorFree: true,
 
-				Files:  []*ast.File{astFile},
+				Files:  astFiles,
 				Errors: nil,
 			},
 		},

--- a/depguard_test.go
+++ b/depguard_test.go
@@ -1,0 +1,130 @@
+package depguard_test
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/OpenPeeDeeP/depguard"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/loader"
+)
+
+func TestBasicAllowList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTWhitelist,
+		Packages: []string{"allow"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow"))
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
+}
+
+func TestPrefixAllowList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTWhitelist,
+		Packages: []string{"allow"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a", "allow/b"))
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
+}
+
+func TestGlobAllowList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTWhitelist,
+		Packages: []string{"allow/**/pkg"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "allow/a/pkg", "allow/a/b/pkg"))
+	require.NoError(t, err)
+	require.Len(t, issues, 0)
+}
+
+func TestBasicDenyList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTBlacklist,
+		Packages: []string{"deny"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny"))
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	require.Equal(t, "deny", issues[0].PackageName)
+	require.Equal(t, "file.go", issues[0].Position.Filename)
+}
+
+func TestPrefixDenyList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTBlacklist,
+		Packages: []string{"deny"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny/a", "deny/b"))
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+	require.Equal(t, "deny/a", issues[0].PackageName)
+	require.Equal(t, "file.go", issues[0].Position.Filename)
+	require.Equal(t, "deny/b", issues[1].PackageName)
+	require.Equal(t, "file.go", issues[1].Position.Filename)
+}
+
+func TestGlobDenyList(t *testing.T) {
+	dg := depguard.Depguard{
+		ListType: depguard.LTBlacklist,
+		Packages: []string{"deny/**/pkg"},
+	}
+
+	issues, err := dg.Run(newLoadConfig(), newProgram("file.go", "deny/a/pkg", "deny/a/b/pkg"))
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+	require.Equal(t, "deny/a/pkg", issues[0].PackageName)
+	require.Equal(t, "file.go", issues[0].Position.Filename)
+	require.Equal(t, "deny/a/b/pkg", issues[1].PackageName)
+	require.Equal(t, "file.go", issues[1].Position.Filename)
+}
+
+func newLoadConfig() *loader.Config {
+	return &loader.Config{
+		Cwd:   "",
+		Build: nil,
+	}
+}
+
+func newProgram(fileName string, packagePaths ...string) *loader.Program {
+	// Build up a mini AST of the information we need to run the linter
+	var packageImports []*ast.ImportSpec
+	for i, _ := range packagePaths {
+		packagePath := packagePaths[i]
+		packageImports = append(packageImports, &ast.ImportSpec{
+			Path: &ast.BasicLit{
+				ValuePos: token.Pos(1),
+				Kind:     token.STRING,
+				Value:    packagePath,
+			},
+		})
+	}
+
+	astFile := &ast.File{
+		Imports: packageImports,
+	}
+
+	progFileSet := token.NewFileSet()
+	progFileSet.AddFile(fileName, 1, 0)
+
+	return &loader.Program{
+		Created: []*loader.PackageInfo{
+			{
+				Pkg:                   nil,
+				Importable:            true,
+				TransitivelyErrorFree: true,
+
+				Files:  []*ast.File{astFile},
+				Errors: nil,
+			},
+		},
+		Fset: progFileSet,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/gobwas/glob v0.2.3
 	github.com/kisielk/gotool v1.0.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b h1:7tibmaEqrQYA+q6ri7NQjuxqSwechjtDHKq6/e85S38=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Hi @dixonwille ,

I'm very interested in using your linter (thank you for writing it), however, I have a use case in which I want to apply package import checks to only a portion of my code base. So I've introduced a new concept which allows a user to write rules to ignore files considered by the linter.

The syntax and semantics of the rules is very nearly the same as those for the package import checks (i.e. string prefixes and string glob patterns). However, there is a small caveat in which the rules have special syntax which allows for negation. I provided examples and a description of this in the README.

You'll also find that I added a number of tests to check the new functionality and avoid regressions. I'm pretty confident that these changes are backwards compatible and include no regression to existing functionality.

Let me know what you think and if there are any other changes that are needed.

Thanks.
-Tim