### PR TITLE
Flesh out the public settings for the linter

### DIFF
--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        dir: [".", "cmd/depguard"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -30,11 +33,16 @@ jobs:
 
     - name: Build
       run: go build -v ./...
+      working-directory: ${{ matrix.dir }}
 
     - name: Test
       run: go test -v ./...
+      working-directory: ${{ matrix.dir }}
 
   lint:
+    strategy:
+      matrix:
+        dir: [".", "cmd/depguard"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -46,3 +54,5 @@ jobs:
 
     - name: Lint
       uses: golangci/golangci-lint-action@v3
+      with:
+        working-directory: ${{ matrix.dir }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "go.formatTool": "goimports",
-    "go.lintTool": "golangci-lint"
+    "go.lintTool": "golangci-lint",
+    "gopls": {
+        "build.experimentalWorkspaceModule": true
+    },
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ matching as it is faster than glob matching. The fewer glob matches the better.
 ## Install
 
 ```bash
-go get -u github.com/OpenPeeDeeP/depguard
+go get github.com/OpenPeeDeeP/depguard/v2
 ```
 
 ## Config

--- a/cmd/depguard/go.mod
+++ b/cmd/depguard/go.mod
@@ -1,0 +1,19 @@
+module github.com/OpenPeeDeeP/depguard/v2/cmd/depguard
+
+go 1.17
+
+replace github.com/OpenPeeDeeP/depguard/v2 => ../../
+
+require (
+	github.com/BurntSushi/toml v1.2.0
+	github.com/OpenPeeDeeP/depguard/v2 v2.0.0-00010101000000-000000000000
+	github.com/google/go-cmp v0.5.8
+	golang.org/x/tools v0.1.12
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/gobwas/glob v0.2.3 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+)

--- a/cmd/depguard/go.sum
+++ b/cmd/depguard/go.sum
@@ -1,8 +1,13 @@
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
+github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -13,6 +18,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -24,3 +30,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/depguard/main.go
+++ b/cmd/depguard/main.go
@@ -1,11 +1,112 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/BurntSushi/toml"
 	depguard "github.com/OpenPeeDeeP/depguard/v2"
 	"golang.org/x/tools/go/analysis/singlechecker"
+	"gopkg.in/yaml.v3"
+)
+
+var configFileRE = regexp.MustCompile(`^\.?depguard\.(yaml|yml|json|toml)$`)
+
+var (
+	fileTypes = map[string]configurator{
+		"toml": &tomlConfigurator{},
+		"yaml": &yamlConfigurator{},
+		"yml":  &yamlConfigurator{},
+		"json": &jsonConfigurator{},
+	}
 )
 
 func main() {
-	analyzer, _ := depguard.NewAnalyzer(&depguard.LinterSettings{})
+	settings, err := getSettings()
+	if err != nil {
+		fmt.Printf("Could not find or read configuration file: %s\nUsing default configuration\n", err)
+		settings = &depguard.LinterSettings{}
+	}
+	analyzer, err := depguard.NewAnalyzer(settings)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	singlechecker.Main(analyzer)
+}
+
+type configurator interface {
+	parse(io.Reader) (*depguard.LinterSettings, error)
+}
+
+type jsonConfigurator struct{}
+
+func (*jsonConfigurator) parse(r io.Reader) (*depguard.LinterSettings, error) {
+	set := &depguard.LinterSettings{}
+	err := json.NewDecoder(r).Decode(set)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse json file: %w", err)
+	}
+	return set, nil
+}
+
+type tomlConfigurator struct{}
+
+func (*tomlConfigurator) parse(r io.Reader) (*depguard.LinterSettings, error) {
+	set := &depguard.LinterSettings{}
+	_, err := toml.NewDecoder(r).Decode(set)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse toml file: %w", err)
+	}
+	return set, nil
+}
+
+type yamlConfigurator struct{}
+
+func (*yamlConfigurator) parse(r io.Reader) (*depguard.LinterSettings, error) {
+	set := &depguard.LinterSettings{}
+	err := yaml.NewDecoder(r).Decode(set)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse yaml file: %w", err)
+	}
+	return set, nil
+}
+
+func getSettings() (*depguard.LinterSettings, error) {
+	fs := os.DirFS(".")
+	f, ft, err := findFile(fs)
+	if err != nil {
+		return nil, err
+	}
+	file, err := fs.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %s to read: %w", f, err)
+	}
+	defer file.Close()
+	return ft.parse(file)
+}
+
+func findFile(fsys fs.FS) (string, configurator, error) {
+	cwd, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return "", nil, fmt.Errorf("could not read cwd: %w", err)
+	}
+	for _, entry := range cwd {
+		if entry.IsDir() {
+			continue
+		}
+		name := strings.ToLower(entry.Name())
+		matches := configFileRE.FindStringSubmatch(name)
+		if len(matches) != 2 {
+			continue
+		}
+		return matches[0], fileTypes[matches[1]], nil
+	}
+	return "", nil, errors.New("unable to find a configuration file")
 }

--- a/cmd/depguard/main_test.go
+++ b/cmd/depguard/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/OpenPeeDeeP/depguard/v2"
+	"github.com/google/go-cmp/cmp"
+)
+
+//go:embed testfiles/*
+var testfiles embed.FS
+
+var expectedConfigStruct = &depguard.LinterSettings{
+	"main": &depguard.List{
+		Files: []string{"$all", "!$test"},
+		Allow: []string{"$gostd", "github.com/"},
+		Deny: map[string]string{
+			"reflect":                "Who needs reflection",
+			"github.com/OpenPeeDeeP": "Use Something Else",
+		},
+	},
+	"tests": &depguard.List{
+		Files: []string{"$test"},
+		Allow: []string{"github.com/test"},
+		Deny: map[string]string{
+			"github.com/OpenPeeDeeP/": "Use Something Else",
+		},
+	},
+}
+
+func TestJsonConfigurator(t *testing.T) {
+	con := &jsonConfigurator{}
+	f, err := testfiles.Open("testfiles/.depguard.json")
+	if err != nil {
+		t.Fatal("could not read embedded file")
+	}
+	set, err := con.parse(f)
+	if err != nil {
+		t.Fatalf("file is not a valid json file: %s", err)
+	}
+	diff := cmp.Diff(expectedConfigStruct, set)
+	if diff != "" {
+		t.Errorf("did not create expected config\n%s", diff)
+	}
+}
+
+func TestYamlConfigurator(t *testing.T) {
+	con := &yamlConfigurator{}
+	f, err := testfiles.Open("testfiles/.depguard.yaml")
+	if err != nil {
+		t.Fatal("could not read embedded file")
+	}
+	set, err := con.parse(f)
+	if err != nil {
+		t.Fatalf("file is not a valid yaml file: %s", err)
+	}
+	diff := cmp.Diff(expectedConfigStruct, set)
+	if diff != "" {
+		t.Errorf("did not create expected config\n%s", diff)
+	}
+}
+
+func TestTomlConfigurator(t *testing.T) {
+	con := &tomlConfigurator{}
+	f, err := testfiles.Open("testfiles/.depguard.toml")
+	if err != nil {
+		t.Fatal("could not read embedded file")
+	}
+	set, err := con.parse(f)
+	if err != nil {
+		t.Fatalf("file is not a valid toml file: %s", err)
+	}
+	diff := cmp.Diff(expectedConfigStruct, set)
+	if diff != "" {
+		t.Errorf("did not create expected config\n%s", diff)
+	}
+}

--- a/cmd/depguard/testfiles/.depguard.json
+++ b/cmd/depguard/testfiles/.depguard.json
@@ -1,0 +1,27 @@
+{
+  "main": {
+    "files": [
+      "$all",
+      "!$test"
+    ],
+    "allow": [
+      "$gostd",
+      "github.com/"
+    ],
+    "deny": {
+      "reflect": "Who needs reflection",
+      "github.com/OpenPeeDeeP": "Use Something Else"
+    }
+  },
+  "tests": {
+    "files": [
+      "$test"
+    ],
+    "allow": [
+      "github.com/test"
+    ],
+    "deny": {
+      "github.com/OpenPeeDeeP/": "Use Something Else"
+    }
+  }
+}

--- a/cmd/depguard/testfiles/.depguard.toml
+++ b/cmd/depguard/testfiles/.depguard.toml
@@ -1,0 +1,22 @@
+[main]
+files = [
+	"$all",
+    "!$test"
+]
+allow = [
+  "$gostd",
+  "github.com/"
+]
+[main.deny]
+reflect = "Who needs reflection"
+"github.com/OpenPeeDeeP" = "Use Something Else"
+
+[tests]
+files = [
+	"$test"
+]
+allow = [
+	"github.com/test"
+]
+[tests.deny]
+"github.com/OpenPeeDeeP/" = "Use Something Else"

--- a/cmd/depguard/testfiles/.depguard.yaml
+++ b/cmd/depguard/testfiles/.depguard.yaml
@@ -1,0 +1,17 @@
+main:
+  files:
+  - "$all"
+  - "!$test"
+  allow:
+  - "$gostd"
+  - github.com/
+  deny:
+    reflect: Who needs reflection
+    github.com/OpenPeeDeeP: Use Something Else
+tests:
+  files:
+  - "$test"
+  allow:
+  - github.com/test
+  deny:
+    github.com/OpenPeeDeeP/: Use Something Else

--- a/depguard.go
+++ b/depguard.go
@@ -1,11 +1,7 @@
 package depguard
 
 import (
-	"fmt"
 	"go/ast"
-	"go/build"
-	"os"
-	"path"
 	"sort"
 	"strings"
 
@@ -13,103 +9,17 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-// ListType states what kind of list is passed in.
-type ListType int
-
-const (
-	// LTDenyList states the list given is a list of packages to deny. (default)
-	LTDenyList ListType = iota
-	// LTAllowList states the list given is a list of package to allow.
-	LTAllowList
-)
-
-// TODO define if certain slices should AND results or OR results accordingly. Is it configurable?
-// TODO Maybe having both prefix and glob is too much to consider the above... Any alternatives that may work better
-// List defines the packages to either allow or deny within certain files.
-// All Globs are compiled with https://pkg.go.dev/github.com/gobwas/glob#Compile.
-// We do add a special case to all globs for negating the match. Prefix the string with "!".
-// EX. *_test.go matches test files where !*_test.go matches anything but test files.
-// Ordering of the different slices does matter as they are treated as an OR operation.
-// AKA first truthy value resolves to a match.
-type List struct {
-	// Globs matching files to use this list for (allow list)
-	// If this list is empty, it is assumes to be applied to every file.
-	// Order matters so the first matching entry assumes the file should be processed by this list.
-	// EX. *_test.go only applies this list to test files
-	// EX. ["packageA/**", "!packageA/foo.go"] will match all files in packageA (because of ordering)
-	// EX. ["!packageA/foo.go", "packageA/**"] will match all files in packageA except for foo.go
-	Files []string
-
-	// The kind of list this is
-	ListType ListType
-
-	// TODO would like a way to make suggestions!
-	// The list of packages this List is concerned about.
-	// Assumed to be a list of package prefixes.
-	// If a glob character is detected, would use a glob match instead.
-	// All non-globs are checked first, then goes through each glob in the order they were defined to try and match.
-	List []string
-
-	// Whether or not this list should try and match against packages found from GOROOT.
-	// EX. os, path, strings, etc.
-	IgnoreGoRootPackages bool
-}
-
-// LinterSettings define how Depguard behaves.
-type LinterSettings struct {
-	// The different lists that Depguard uses for import matching.
-	// The order in which the lists are defined is important.
-	// The first list to match on a file is used.
-	Lists []*List
-}
-
-// V1Settings is used for backwards compatibility only and should move to the new LinterSettings if possible.
-// Deprecated: Use LinterSettings instead.
-type V1Settings struct {
-	ListType        ListType
-	IncludeGoRoot   bool
-	Packages        []string
-	TestPackages    []string
-	IgnoreFileRules []string
-}
-
-// NewAnalyzerFromV2Settings returns an Analyzer from V1's settings.
-// Deprecated: Use NewAnalyzer instead.
-func NewAnalyzerFromV1Settings(settings *V1Settings) (*analysis.Analyzer, error) {
-	ls := &LinterSettings{}
-	// TODO find a way to handle the old IgnoreFileRules (mix of glob and prefix)
-	hasTestList := false
-	if len(settings.TestPackages) > 0 {
-		hasTestList = true
-		ls.Lists = append(ls.Lists, &List{
-			Files:                []string{"*_test.go"},
-			ListType:             settings.ListType,
-			List:                 settings.TestPackages,
-			IgnoreGoRootPackages: !settings.IncludeGoRoot,
-		})
-	}
-	if len(settings.Packages) > 0 {
-		files := []string{}
-		if hasTestList {
-			files = append(files, "!*_test.go")
-		}
-		ls.Lists = append(ls.Lists, &List{
-			Files:                files,
-			ListType:             settings.ListType,
-			List:                 settings.Packages,
-			IgnoreGoRootPackages: !settings.IncludeGoRoot,
-		})
-	}
-	return NewAnalyzer(ls)
-}
-
 // NewAnalyzer creates a new analyzer from the settings passed in
 func NewAnalyzer(settings *LinterSettings) (*analysis.Analyzer, error) {
-	analyzer := newAnalyzer(settings)
+	s, err := settings.compile()
+	if err != nil {
+		return nil, err
+	}
+	analyzer := newAnalyzer(s)
 	return analyzer, nil
 }
 
-func newAnalyzer(settings *LinterSettings) *analysis.Analyzer {
+func newAnalyzer(settings linterSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
 		Name:             "Debguard",
 		Doc:              "Go linter that checks if package imports are in a list of acceptable packages",
@@ -118,7 +28,7 @@ func newAnalyzer(settings *LinterSettings) *analysis.Analyzer {
 	}
 }
 
-func (s *LinterSettings) run(pass *analysis.Pass) (interface{}, error) {
+func (s linterSettings) run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
 		for _, imp := range file.Imports {
 			pass.ReportRangef(imp, "%s is an import", rawBasicLit(imp.Path))
@@ -149,24 +59,6 @@ func strInGlobList(str string, globList []glob.Glob) bool {
 		}
 	}
 	return false
-}
-
-// We can do this as all imports that are not root are either prefixed with a domain
-// or prefixed with `./` or `/` to dictate it is a local file reference
-func listGoRootPrefixes() ([]string, error) {
-	root := path.Join(build.Default.GOROOT, "src")
-	fs, err := os.ReadDir(root)
-	if err != nil {
-		return nil, fmt.Errorf("could not read GOROOT directory: %w", err)
-	}
-	var pkgPrefix []string
-	for _, f := range fs {
-		if !f.IsDir() {
-			continue
-		}
-		pkgPrefix = append(pkgPrefix, f.Name())
-	}
-	return pkgPrefix, nil
 }
 
 func rawBasicLit(lit *ast.BasicLit) string {

--- a/depguard_test.go
+++ b/depguard_test.go
@@ -63,23 +63,3 @@ func TestStrInGlobList(t *testing.T) {
 	t.Run("match", testStrInGlobList("some/foo/bar/a", true))
 	t.Run("no_match", testStrInGlobList("some/foo/b", false))
 }
-
-func TestListGoRootPrefixes(t *testing.T) {
-	pre, err := listGoRootPrefixes()
-	if err != nil {
-		t.FailNow()
-	}
-	// Just make sure a few are in there
-	if !contains(pre, "os") && !contains(pre, "strings") {
-		t.Fail()
-	}
-}
-
-func contains(sl []string, str string) bool {
-	for _, s := range sl {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,3 @@ require (
 	github.com/gobwas/glob v0.2.3
 	golang.org/x/tools v0.1.12
 )
-
-require (
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
-)

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"strings"
+)
+
+type MultiError []error
+
+func (me MultiError) Error() string {
+	b := strings.Builder{}
+	for i, e := range me {
+		b.WriteString(e.Error())
+		if i < len(me)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/internal/utils/variables.go
+++ b/internal/utils/variables.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"path"
+)
+
+type Expander interface {
+	Expand() ([]string, error)
+}
+
+var (
+	PathExpandable = map[string]Expander{
+		"$all":  &allExpander{},
+		"$test": &testExpander{},
+	}
+	PackageExpandable = map[string]Expander{
+		"$gostd": &gostdExpander{},
+	}
+)
+
+type allExpander struct{}
+
+func (*allExpander) Expand() ([]string, error) {
+	return []string{"**/*.go"}, nil
+}
+
+type testExpander struct{}
+
+func (*testExpander) Expand() ([]string, error) {
+	return []string{"**/*_test.go"}, nil
+}
+
+type gostdExpander struct {
+	cache []string
+}
+
+// We can do this as all imports that are not root are either prefixed with a domain
+// or prefixed with `./` or `/` to dictate it is a local file reference
+func (e *gostdExpander) Expand() ([]string, error) {
+	if len(e.cache) != 0 {
+		return e.cache, nil
+	}
+	root := path.Join(build.Default.GOROOT, "src")
+	fs, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("could not read GOROOT directory: %w", err)
+	}
+	var pkgPrefix []string
+	for _, f := range fs {
+		if !f.IsDir() {
+			continue
+		}
+		pkgPrefix = append(pkgPrefix, f.Name())
+	}
+	e.cache = pkgPrefix
+	return pkgPrefix, nil
+}

--- a/internal/utils/variables_test.go
+++ b/internal/utils/variables_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/gobwas/glob"
+)
+
+func TestAllExpander(t *testing.T) {
+	exp := &allExpander{}
+	pre, err := exp.Expand()
+	if err != nil {
+		t.Fatal("expansion method returned an error")
+	}
+	if len(pre) != 1 {
+		t.Fatal("expected only 1 expansion")
+	}
+	g, err := glob.Compile(pre[0], '/')
+	if err != nil {
+		t.Fatal("glob is not compilable")
+	}
+	if !g.Match("/some/folder/system/some_test.go") {
+		t.Error("glob should match a test file")
+	}
+	if !g.Match("/some/folder/system/some.go") {
+		t.Error("glob should not match a normal go file")
+	}
+}
+
+func TestTestExpander(t *testing.T) {
+	exp := &testExpander{}
+	pre, err := exp.Expand()
+	if err != nil {
+		t.Fatal("expansion method returned an error")
+	}
+	if len(pre) != 1 {
+		t.Fatal("expected only 1 expansion")
+	}
+	g, err := glob.Compile(pre[0], '/')
+	if err != nil {
+		t.Fatal("glob is not compilable")
+	}
+	if g.Match("/some/folder/system/some.go") {
+		t.Error("glob should not match a normal go file")
+	}
+	if !g.Match("/some/folder/system/some_test.go") {
+		t.Error("glob doesn't match a test file")
+	}
+}
+
+func TestGoStdExpander(t *testing.T) {
+	exp := &gostdExpander{}
+	pre, err := exp.Expand()
+	if err != nil {
+		t.Fatal("expansion method returned an error")
+	}
+	if len(pre) == 0 {
+		t.Fatal("expected more than 1 expansion")
+	}
+	// Just make sure a few are in there
+	if !contains(pre, "os") && !contains(pre, "strings") {
+		t.Error("could not find some of the expected packages")
+	}
+}
+
+func contains(sl []string, str string) bool {
+	for _, s := range sl {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/settings.go
+++ b/settings.go
@@ -1,0 +1,126 @@
+package depguard
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/OpenPeeDeeP/depguard/v2/internal/utils"
+	"github.com/gobwas/glob"
+)
+
+type List struct {
+	Files []string          `json:"files" yaml:"files" toml:"files"`
+	Allow []string          `json:"allow" yaml:"allow" toml:"allow"`
+	Deny  map[string]string `json:"deny" yaml:"deny" toml:"deny"`
+}
+
+type listMode int
+
+const (
+	lmAllow listMode = iota // Only packages in allow are allowed
+	lmDeny                  // Any package in deny is blocked
+	lmMixed                 // Package must exist in allow and not be blocked in deny
+)
+
+type list struct {
+	name        string
+	files       []glob.Glob
+	listMode    listMode
+	allow       []string
+	deny        []string
+	suggestions []string
+}
+
+func (l *List) compile() (*list, error) {
+	li := &list{}
+	var errs utils.MultiError
+	// TODO Expand Files
+	// TODO Split files to negatable globs
+
+	// Compile Files
+	li.files = make([]glob.Glob, 0, len(l.Files))
+	for _, f := range l.Files {
+		g, err := glob.Compile(f, '/')
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s could not be compiled: %w", f, err))
+			continue
+		}
+		li.files = append(li.files, g)
+	}
+
+	// TODO Expand Allow
+
+	// Sort Allow
+	li.allow = make([]string, len(l.Allow))
+	copy(li.allow, l.Allow)
+	sort.Strings(li.allow)
+
+	// TODO Expand Deny Map (to keep suggestions)
+
+	// Split Deny Into Package Slice
+	li.deny = make([]string, 0, len(l.Deny))
+	for pkg := range l.Deny {
+		li.deny = append(li.deny, pkg)
+	}
+
+	// Sort Deny
+	sort.Strings(li.deny)
+
+	// Populate Suggestions to match the Deny order
+	li.suggestions = make([]string, 0, len(li.deny))
+	for _, dp := range li.deny {
+		li.suggestions = append(li.suggestions, strings.TrimSpace(l.Deny[dp]))
+	}
+
+	if len(li.allow) > 0 && len(li.deny) > 0 {
+		li.listMode = lmMixed
+	} else if len(li.allow) > 0 {
+		li.listMode = lmAllow
+	} else if len(li.deny) > 0 {
+		li.listMode = lmDeny
+	} else {
+		return nil, errors.New("must have an Allow and/or Deny package list")
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return li, nil
+}
+
+type LinterSettings map[string]*List
+
+type linterSettings []*list
+
+func (l LinterSettings) compile() (linterSettings, error) {
+	if len(l) == 0 {
+		// Only allow $gostd in all files
+		set := &List{
+			Allow: []string{"$gostd"},
+		}
+		li, err := set.compile()
+		if err != nil {
+			return nil, err
+		}
+		return linterSettings{li}, nil
+	}
+
+	li := make(linterSettings, 0, len(l))
+	var errs utils.MultiError
+	for name, set := range l {
+		c, err := set.compile()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		c.name = name
+		li = append(li, c)
+	}
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return li, nil
+}


### PR DESCRIPTION
## Standalone linter

- Ability to read json/yaml/toml setting files name `depguard.yml` or `.depguard.yml`
- If a settings file couldn't be used, have a fall back

## Organization

- The binary is now a separate go module as to not bloat package
- Updated github actions to know about both modules
- Split out code into more manageable files

## Features

- Ability to have expanded variables in the list
    - $gostd, $all, $test as an example
- "Compile" the settings to usable structs for the main run to function
    - done in a way so that cost is only when creating analyzer and not on run