### PR TITLE
Fix install cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ allow specific packages within a repository.
 ## Install
 
 ```bash
-go install github.com/OpenPeeDeeP/depguard@latest
+go install github.com/OpenPeeDeeP/depguard/cmd/depguard@latest
 ```
 
 ## Config


### PR DESCRIPTION
The current install cmd doesn't work for me

```bash
➜  ~ go install github.com/OpenPeeDeeP/depguard@latest
go: downloading github.com/OpenPeeDeeP/depguard v1.1.1
go: downloading github.com/gobwas/glob v0.2.3
go: downloading golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b
package github.com/OpenPeeDeeP/depguard is not a main package
```